### PR TITLE
fix: remove mentions of the template repo from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,3 @@ To install the Semgrep Claude Plugin:
    /setup-semgrep-plugin
     ```
 1. If you run into issues, please reach out in the [Semgrep Community Slack](https://semgrep.slack.com/) and join the #mcp channel.
-  
-
-## Contributing
-
-This plugin is managed by the [mcp-marketplace-template](https://github.com/semgrep/mcp-marketplace-template) repository. Changes should be made there and synced via automated PRs.


### PR DESCRIPTION
It seems like it is harder to maintain the template repo, so I am going to remove it. We should also remove all mentions of it in the plugin repos.