### PR TITLE
Fix hook.sh routing to Windows binary under native WSL2

### DIFF
--- a/plugin/scripts/hook.sh
+++ b/plugin/scripts/hook.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 DIR="$(cd "$(dirname "$0")" && pwd)"
 
-if [[ -n "$WSL_DISTRO_NAME" ]]; then
-  exec "$DIR/hook-windows-amd64.exe" "$@"
-fi
-
 case "$OSTYPE" in
   darwin*)
     case "$HOSTTYPE" in


### PR DESCRIPTION
## Summary
- `plugin/scripts/hook.sh` routed every invocation to `hook-windows-amd64.exe` whenever `WSL_DISTRO_NAME` was set, but that env var is present for *any* process inside a WSL distro — including a genuinely native Linux install of Claude Code, not just Windows processes reaching in via WSL interop.
- In that (very common) case, the Windows binary can't lock/access its settings from the Linux side, producing `Could not lock settings, can't login` on essentially every `PreToolUse`/`PostToolUse`/`SessionStart` hook call.
- Removes the special-cased `WSL_DISTRO_NAME` branch entirely and lets the existing `$OSTYPE` case handle it — `$OSTYPE` already resolves to `linux-gnu` under WSL2, so the correct `hook-linux-{amd64,arm64}` binary gets picked automatically.

Fixes #66

## Test plan
- [x] Reproduced the bug on WSL2 (Ubuntu 26.04, `WSL_DISTRO_NAME=Ubuntu`, `OSTYPE=linux-gnu`, `HOSTTYPE=x86_64`): before this change, `hook.sh` execs `hook-windows-amd64.exe`; after this change, it execs `hook-linux-amd64`.
- [ ] Would appreciate a maintainer confirming there isn't a legitimate scenario this WSL branch was meant to cover (e.g. a Windows-native Claude Code build shelling out via `wsl.exe`) that this removal regresses — I couldn't find one, since such a process would also present as `OSTYPE=linux-gnu` inside the WSL shell and still need the Linux binary to execute correctly there.